### PR TITLE
StringUtil#remove(char): copy chars by chunk instead of one by one

### DIFF
--- a/src/main/java/jodd/util/StringUtil.java
+++ b/src/main/java/jodd/util/StringUtil.java
@@ -254,20 +254,22 @@ public class StringUtil {
 	 * @param ch  character to remove
 	 */
 	public static String remove(final String string, final char ch) {
-		if (isEmpty(string)) {
+		int originalNdx = string.indexOf(ch);
+		if (originalNdx == -1) {
 			return string;
 		}
 
-		final int stringLen = string.length();
-
 		return StringBuilderPool.DEFAULT.withPooledBuffer(sb -> {
-			for (int i = 0; i < stringLen; i++) {
-				final char c = string.charAt(i);
-				if (c != ch) {
-					sb.append(c);
-				}
+			int offset = 0;
+			int ndx = originalNdx;
+			while (ndx != -1) {
+				sb.append(string, offset, ndx);
+				offset = ndx + 1;
+				ndx = string.indexOf(ch, offset);
 			}
-			return sb.length() == stringLen ? string : sb.toString();
+			// tail
+			sb.append(string, offset, string.length());
+			return sb.toString();
 		});
 	}
 

--- a/src/test/java/jodd/util/StringUtilTest.java
+++ b/src/test/java/jodd/util/StringUtilTest.java
@@ -372,6 +372,15 @@ class StringUtilTest {
 	}
 
 	@Test
+	void testRemoveSingleChar() {
+		assertEquals("werty", StringUtil.remove("qwerty", 'q'));
+		assertEquals("qwert", StringUtil.remove("qwerty", 'y'));
+		assertEquals("qwrty", StringUtil.remove("qwerty", 'e'));
+		assertEquals("qwerty", StringUtil.remove("qwerty", 'a'));
+		assertEquals("", StringUtil.remove("", 'q'));
+	}
+
+	@Test
 	void testArrays() {
 		final String s = "qwertyuiop";
 


### PR DESCRIPTION
Motivation:

Chars are currently copied one by one in the StringBuilder.

Modification:

Use String#indexOf to locate char position and then StringBuilder#append(string, start, end) to copy chars by chunk.

Result:

Better performance.