### PR TITLE
Assignment 1: 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,33 @@ jacocoTestReport {
 check.dependsOn jacocoTestReport
 
 //
+// JMH
+//
+
+sourceSets {
+	jmh
+}
+
+dependencies {
+	jmhCompile project
+	jmhCompile 'org.openjdk.jmh:jmh-core:1.25.2'
+	jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.25.2'
+}
+
+tasks.addRule("Pattern: <ClassName>Benchmark : Run benchmark.") { String taskName ->
+	if (taskName.endsWith("Benchmark")) {
+		println "\nRunning Benchmark: " + taskName + "\n"
+
+		task "$taskName"(type: JavaExec, dependsOn: 'build') {
+			main 'org.openjdk.jmh.Main'
+			args =  ['.' + taskName + '.*']
+//				jvmArgs = ["-XX:+PrintCompilation"]
+			classpath = sourceSets.main.runtimeClasspath + sourceSets.jmh.runtimeClasspath
+		}
+	}
+}
+
+//
 // PUBLISH
 //
 

--- a/src/jmh/java/jodd/util/CharUtil_isWhitespaceBenchmark.java
+++ b/src/jmh/java/jodd/util/CharUtil_isWhitespaceBenchmark.java
@@ -1,0 +1,85 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+package jodd.util;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Benchmark for {@link CharUtil#isWhitespace(char)} method.
+ * <pre>
+
+gradlew CharUtil_isWhitespaceBenchmark
+
+CharUtil_isWhitespaceBenchmark.isWhitespace_Java  thrpt   10   12372.132 ±   79.043  ops/ms
+CharUtil_isWhitespaceBenchmark.isWhitespace_Jodd  thrpt   10  379723.479 ± 3997.047  ops/ms
+
+ </pre>
+ */
+@Fork(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class CharUtil_isWhitespaceBenchmark {
+
+	private final char[] chars = new char[256];
+
+	@Setup
+	public void prepare() {
+		for (int c = 0 ; c < chars.length ; c++) {
+			chars[c] = (char) c;
+		}
+	}
+
+	@Benchmark
+	public boolean isWhitespace_Java() {
+		boolean result = false;
+		for (final char aChar : chars) {
+			result = result || Character.isWhitespace(aChar);
+		}
+		return result;
+	}
+
+	@Benchmark
+	public boolean isWhitespace_Jodd() {
+		boolean result = false;
+		for (final char aChar : chars) {
+			result = result || CharUtil.isWhitespace(aChar);
+		}
+		return result;
+	}
+}

--- a/src/jmh/java/jodd/util/StringUtil_removeBenchmark.java
+++ b/src/jmh/java/jodd/util/StringUtil_removeBenchmark.java
@@ -1,0 +1,78 @@
+package jodd.util;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ *
+ * <pre>
+gradlew StringUtil_removeBenchmark
+
+StringUtil_removeBenchmark.removeNew                a  thrpt    5  29089.686 ± 222.621  ops/ms
+StringUtil_removeBenchmark.removeNew               ba  thrpt    5  24278.007 ± 145.268  ops/ms
+StringUtil_removeBenchmark.removeNew              cab  thrpt    5  22196.510 ± 212.803  ops/ms
+StringUtil_removeBenchmark.removeNew            abcde  thrpt    5  23367.545 ± 430.193  ops/ms
+StringUtil_removeBenchmark.removeNew  bcdefghaijklman  thrpt    5  17268.509 ± 163.351  ops/ms
+StringUtil_removeBenchmark.removeOld                a  thrpt    5  57116.090 ± 881.963  ops/ms
+StringUtil_removeBenchmark.removeOld               ba  thrpt    5  40605.504 ± 463.230  ops/ms
+StringUtil_removeBenchmark.removeOld              cab  thrpt    5  40103.663 ± 609.040  ops/ms
+StringUtil_removeBenchmark.removeOld            abcde  thrpt    5  35670.546 ± 535.558  ops/ms
+StringUtil_removeBenchmark.removeOld  bcdefghaijklman  thrpt    5  29990.477 ± 348.026  ops/ms
+
+ * </pre>
+ */
+@Fork(1)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+@BenchmarkMode(Mode.Throughput)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class StringUtil_removeBenchmark {
+
+	public static String removeOld(final String string, final char ch) {
+		final int stringLen = string.length();
+		final char[] result = new char[stringLen];
+		int offset = 0;
+
+		for (int i = 0; i < stringLen; i++) {
+			final char c = string.charAt(i);
+
+			if (c == ch) {
+				continue;
+			}
+
+			result[offset] = c;
+			offset++;
+		}
+
+		if (offset == stringLen) {
+			return string;
+		}
+
+		return new String(result, 0, offset);
+	}
+
+	@Param({"a", "ba", "cab", "abcde", "bcdefghaijklman"})
+	public String source;
+
+	@Benchmark
+	public String removeNew() {
+		return StringUtil.remove(source, 'a');
+	}
+
+	@Benchmark
+	public String removeOld() {
+		return removeOld(source, 'a');
+	}
+
+}

--- a/src/jmh/java/jodd/util/StringUtil_replaceBenchmark.java
+++ b/src/jmh/java/jodd/util/StringUtil_replaceBenchmark.java
@@ -1,0 +1,146 @@
+// Copyright (c) 2003-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+package jodd.util;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmark for {@link StringUtil#replace(String, String, String)} method. <br/>
+ * Following methods will be compared:
+ * <ol>
+ *     <li>{@link String#replace(CharSequence, CharSequence)}</li>
+ *     <li>{@link StringUtil#replace(String, String, String)}</li>
+ * </ol>
+ *
+ * Code was originally published on <a href="https://blog.jooq.org/2017/10/11/benchmarking-jdk-string-replace-vs-apache-commons-stringutils-replace/#comment-151887">jOOQ blog</a> , but slightly modified.
+ *
+ * <p>
+ * Run:
+ * <code>
+ * gw :jodd-core:StringUtilReplaceBenchmark
+ * </code>
+ * </p>
+ *
+ * Results:
+ * <pre>
+ * Benchmark                                                                      Mode  Cnt          Score          Error  Units
+ * StringUtilReplaceBenchmark.stringReplaceLongStringNoMatch                     thrpt   21    6309114.450 ±    90470.839  ops/s
+ * StringUtilReplaceBenchmark.stringReplaceLongStringOneMatch                    thrpt   21    1854754.382 ±    43681.835  ops/s
+ * StringUtilReplaceBenchmark.stringReplaceLongStringSeveralMatches              thrpt   21    1412900.760 ±    22663.776  ops/s
+ * StringUtilReplaceBenchmark.stringReplaceShortStringNoMatch                    thrpt   21    7600231.241 ±   116226.095  ops/s
+ * StringUtilReplaceBenchmark.stringReplaceShortStringOneMatch                   thrpt   21    4406405.853 ±   146412.852  ops/s
+ * StringUtilReplaceBenchmark.stringReplaceShortStringSeveralMatches             thrpt   21    2952897.725 ±    26047.413  ops/s
+ * StringUtilReplaceBenchmark.stringUtilReplaceLongStringNoMatch                 thrpt   21   31411667.415 ±   451647.428  ops/s
+ * StringUtilReplaceBenchmark.stringUtilReplaceLongStringOneMatch                thrpt   21   10121698.874 ±   152851.456  ops/s
+ * StringUtilReplaceBenchmark.stringUtilReplaceLongStringSeveralMatches          thrpt   21    5091103.201 ±   136616.407  ops/s
+ * StringUtilReplaceBenchmark.stringUtilReplaceShortStringNoMatch                thrpt   21  207213639.747 ±  5682502.409  ops/s
+ * StringUtilReplaceBenchmark.stringUtilReplaceShortStringOneMatch               thrpt   21   19425478.685 ±   766128.831  ops/s
+ * StringUtilReplaceBenchmark.stringUtilReplaceShortStringSeveralMatches         thrpt   21    9633490.491 ±   159050.223  ops/s
+ * </pre>
+ *
+ * <b>Note:</b> in Java 9 the method {@link String#replace(CharSequence, CharSequence)} will perform much better!
+ */
+@Fork(value = 3, jvmArgsAppend = "-Djmh.stack.lines=3")
+@Warmup(iterations = 5)
+@Measurement(iterations = 7)
+public class StringUtil_replaceBenchmark {
+
+    private static final String SHORT_STRING_NO_MATCH = "abc";
+    private static final String SHORT_STRING_ONE_MATCH = "a'bc";
+    private static final String SHORT_STRING_SEVERAL_MATCHES = "'a'b'c'";
+    private static final String LONG_STRING_NO_MATCH =
+            "abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc";
+    private static final String LONG_STRING_ONE_MATCH =
+            "abcabcabcabcabcabcabcabcabcabcabca'bcabcabcabcabcabcabcabcabcabcabcabcabc";
+    private static final String LONG_STRING_SEVERAL_MATCHES =
+            "abcabca'bcabcabcabcabcabc'abcabcabca'bcabcabcabcabcabca'bcabcabcabcabcabcabc";
+
+    // ----------------------------------------------------------------------- Java String#replace
+    
+    @Benchmark
+    public String stringReplaceShortStringNoMatch() {
+        return SHORT_STRING_NO_MATCH.replace("'", "''");
+    }
+
+    @Benchmark
+    public String stringReplaceLongStringNoMatch() {
+        return LONG_STRING_NO_MATCH.replace("'", "''");
+    }
+
+    @Benchmark
+    public String stringReplaceShortStringOneMatch() {
+        return SHORT_STRING_ONE_MATCH.replace("'", "''");
+    }
+
+    @Benchmark
+    public String stringReplaceLongStringOneMatch() {
+        return LONG_STRING_ONE_MATCH.replace("'", "''");
+    }
+
+    @Benchmark
+    public String stringReplaceShortStringSeveralMatches() {
+        return SHORT_STRING_SEVERAL_MATCHES.replace("'", "''");
+    }
+
+    @Benchmark
+    public String stringReplaceLongStringSeveralMatches() {
+        return LONG_STRING_SEVERAL_MATCHES.replace("'", "''");
+    }
+
+    // ----------------------------------------------------------------------- Jodd StringUtil#replace
+
+    @Benchmark
+    public String stringUtilReplaceShortStringNoMatch() {
+        return StringUtil.replace(SHORT_STRING_NO_MATCH, "'", "''");
+    }
+
+    @Benchmark
+    public String stringUtilReplaceLongStringNoMatch() {
+        return StringUtil.replace(LONG_STRING_NO_MATCH, "'", "''");
+    }
+
+    @Benchmark
+    public String stringUtilReplaceShortStringOneMatch() {
+        return StringUtil.replace(SHORT_STRING_ONE_MATCH, "'", "''");
+    }
+
+    @Benchmark
+    public String stringUtilReplaceLongStringOneMatch() {
+        return StringUtil.replace(LONG_STRING_ONE_MATCH, "'", "''");
+    }
+
+    @Benchmark
+    public String stringUtilReplaceShortStringSeveralMatches() {
+        return StringUtil.replace(SHORT_STRING_SEVERAL_MATCHES, "'", "''");
+    }
+
+    @Benchmark
+    public String stringUtilReplaceLongStringSeveralMatches() {
+        return StringUtil.replace(LONG_STRING_SEVERAL_MATCHES, "'", "''");
+    }
+}

--- a/src/main/java/jodd/net/HtmlDecoder.java
+++ b/src/main/java/jodd/net/HtmlDecoder.java
@@ -158,7 +158,7 @@ public class HtmlDecoder {
 						}
 						ndx = html.indexOf('&', lastIndex);
 					}
-					result.append(html.substring(lastIndex));
+					result.append(html, lastIndex, len);
 					return result.toString();
 				}
 		);

--- a/src/main/java/jodd/net/HtmlDecoder.java
+++ b/src/main/java/jodd/net/HtmlDecoder.java
@@ -28,6 +28,7 @@ package jodd.net;
 import jodd.io.IOUtil;
 import jodd.util.BinarySearchBase;
 import jodd.util.CharUtil;
+import jodd.util.StringBuilderPool;
 import jodd.util.StringUtil;
 
 import java.io.InputStream;
@@ -104,61 +105,63 @@ public class HtmlDecoder {
 	 */
 	public static String decode(final String html) {
 
-		int ndx = html.indexOf('&');
-		if (ndx == -1) {
+		final int originalNdx = html.indexOf('&');
+		if (originalNdx == -1) {
 			return html;
 		}
 
-		final StringBuilder result = new StringBuilder(html.length());
+		return StringBuilderPool.DEFAULT.withPooledBuffer(result -> {
+					int lastIndex = 0;
+					final int len = html.length();
+					int ndx = originalNdx;
+					mainloop:
+					while (ndx != -1) {
+						result.append(html, lastIndex, ndx);
 
-		int lastIndex = 0;
-		final int len = html.length();
-mainloop:
-		while (ndx != -1) {
-			result.append(html.substring(lastIndex, ndx));
+						lastIndex = ndx;
+						while (html.charAt(lastIndex) != ';') {
+							lastIndex++;
+							if (lastIndex == len) {
+								lastIndex = ndx;
+								break mainloop;
+							}
+						}
 
-			lastIndex = ndx;
-			while (html.charAt(lastIndex) != ';') {
-				lastIndex++;
-				if (lastIndex == len) {
-					lastIndex = ndx;
-					break mainloop;
+						if (html.charAt(ndx + 1) == '#') {
+							// decimal/hex
+							final char c = html.charAt(ndx + 2);
+							final int radix;
+							if ((c == 'x') || (c == 'X')) {
+								radix = 16;
+								ndx += 3;
+							} else {
+								radix = 10;
+								ndx += 2;
+							}
+
+							final String number = html.substring(ndx, lastIndex);
+							final int i = Integer.parseInt(number, radix);
+							result.append((char) i);
+							lastIndex++;
+						} else {
+							// token
+							final String encodeToken = html.substring(ndx + 1, lastIndex);
+
+							final char[] replacement = ENTITY_MAP.get(encodeToken);
+							if (replacement == null) {
+								result.append('&');
+								lastIndex = ndx + 1;
+							} else {
+								result.append(replacement);
+								lastIndex++;
+							}
+						}
+						ndx = html.indexOf('&', lastIndex);
+					}
+					result.append(html.substring(lastIndex));
+					return result.toString();
 				}
-			}
-
-			if (html.charAt(ndx + 1) == '#') {
-				// decimal/hex
-				final char c = html.charAt(ndx + 2);
-				final int radix;
-				if ((c == 'x') || (c == 'X')) {
-					radix = 16;
-					ndx += 3;
-				} else {
-					radix = 10;
-					ndx += 2;
-				}
-
-				final String number = html.substring(ndx, lastIndex);
-				final int i = Integer.parseInt(number, radix);
-				result.append((char) i);
-				lastIndex++;
-			} else {
-				// token
-				final String encodeToken = html.substring(ndx + 1, lastIndex);
-
-				final char[] replacement = ENTITY_MAP.get(encodeToken);
-				if (replacement == null) {
-					result.append('&');
-					lastIndex = ndx + 1;
-				} else {
-					result.append(replacement);
-					lastIndex++;
-				}
-			}
-			ndx = html.indexOf('&', lastIndex);
-		}
-		result.append(html.substring(lastIndex));
-		return result.toString();
+		);
 	}
 
 	private static final class Ptr {

--- a/src/main/java/jodd/net/HtmlEncoder.java
+++ b/src/main/java/jodd/net/HtmlEncoder.java
@@ -25,6 +25,7 @@
 
 package jodd.net;
 
+import jodd.util.StringBuilderPool;
 import jodd.util.StringPool;
 
 /**
@@ -135,24 +136,22 @@ public class HtmlEncoder {
 	// ---------------------------------------------------------------- private
 
 	private static String encode(final CharSequence text, final char[][] buff, final int bufflen) {
-		int len;
+		final int len;
 		if ((text == null) || ((len = text.length()) == 0)) {
 			return StringPool.EMPTY;
 		}
 
-		StringBuilder buffer = new StringBuilder(len + (len >> 2));
-
-		for (int i = 0; i < len; i++) {
-			char c = text.charAt(i);
-
-			if (c < bufflen) {
-				buffer.append(buff[c]);
-			} else {
-				buffer.append(c);
-			}
-		}
-		return buffer.toString();
+		return StringBuilderPool.DEFAULT.withPooledBuffer(sb -> {
+					for (int i = 0; i < len; i++) {
+						final char c = text.charAt(i);
+						if (c < bufflen) {
+							sb.append(buff[c]);
+						} else {
+							sb.append(c);
+						}
+					}
+					return sb.toString();
+				}
+		);
 	}
-
-
 }

--- a/src/main/java/jodd/util/StringBuilderPool.java
+++ b/src/main/java/jodd/util/StringBuilderPool.java
@@ -41,7 +41,12 @@ public class StringBuilderPool {
 
 	private StringBuilder poll() {
 		final StringBuilder sb = pool.poll();
-		return sb != null ? sb : new StringBuilder();
+		if (sb != null) {
+			sb.setLength(0);
+			return sb;
+		} else {
+			return new StringBuilder();
+		}
 	}
 
 	private void offer(final StringBuilder sb) {

--- a/src/main/java/jodd/util/StringBuilderPool.java
+++ b/src/main/java/jodd/util/StringBuilderPool.java
@@ -1,0 +1,59 @@
+// Copyright (c) 2020-present, Jodd Team (http://jodd.org)
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice,
+// this list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+
+package jodd.util;
+
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Function;
+
+public class StringBuilderPool {
+
+	public static StringBuilderPool DEFAULT = new StringBuilderPool(10_000);
+
+	private final ConcurrentLinkedQueue<StringBuilder> pool = new ConcurrentLinkedQueue<>();
+	private final int maxPooledLength;
+
+	public StringBuilderPool(final int maxPooledLength) {
+		this.maxPooledLength = maxPooledLength;
+	}
+
+	private StringBuilder poll() {
+		final StringBuilder sb = pool.poll();
+		return sb != null ? sb : new StringBuilder();
+	}
+
+	private void offer(final StringBuilder sb) {
+		if (sb.length() <= maxPooledLength) {
+			pool.offer(sb);
+		}
+	}
+
+	public <T> T withPooledBuffer(final Function<StringBuilder, T> f) {
+		final StringBuilder sb = poll();
+		final T res = f.apply(sb);
+		offer(sb);
+		return res;
+	}
+}

--- a/src/main/java/jodd/util/StringUtil.java
+++ b/src/main/java/jodd/util/StringUtil.java
@@ -254,26 +254,21 @@ public class StringUtil {
 	 * @param ch  character to remove
 	 */
 	public static String remove(final String string, final char ch) {
+		if (isEmpty(string)) {
+			return string;
+		}
+
 		final int stringLen = string.length();
-		final char[] result = new char[stringLen];
-		int offset = 0;
 
-		for (int i = 0; i < stringLen; i++) {
-			final char c = string.charAt(i);
-
-			if (c == ch) {
-				continue;
+		return StringBuilderPool.DEFAULT.withPooledBuffer(sb -> {
+			for (int i = 0; i < stringLen; i++) {
+				final char c = string.charAt(i);
+				if (c != ch) {
+					sb.append(c);
+				}
 			}
-
-			result[offset] = c;
-			offset++;
-		}
-
-		if (offset == stringLen) {
-			return string;	// no changes
-		}
-
-		return new String(result, 0, offset);
+			return sb.length() == stringLen ? string : sb.toString();
+		});
 	}
 
 	// ---------------------------------------------------------------- miscellaneous

--- a/src/main/java/jodd/util/StringUtil.java
+++ b/src/main/java/jodd/util/StringUtil.java
@@ -254,20 +254,22 @@ public class StringUtil {
 	 * @param ch  character to remove
 	 */
 	public static String remove(final String string, final char ch) {
-		if (isEmpty(string)) {
+		int originalNdx = string.indexOf(ch);
+		if (originalNdx == -1) {
 			return string;
 		}
 
-		final int stringLen = string.length();
-
 		return StringBuilderPool.DEFAULT.withPooledBuffer(sb -> {
-			for (int i = 0; i < stringLen; i++) {
-				final char c = string.charAt(i);
-				if (c != ch) {
-					sb.append(c);
-				}
+			int offset = 0;
+			int ndx = originalNdx;
+			while (ndx != -1) {
+				sb.append(string, offset, ndx);
+				offset = ndx + 1;
+				ndx = string.indexOf(ch, offset);
 			}
-			return sb.length() == stringLen ? string : sb.toString();
+			// tail
+			sb.append(string, offset, string.length());
+			return sb.toString();
 		});
 	}
 

--- a/src/test/java/jodd/util/StringUtilTest.java
+++ b/src/test/java/jodd/util/StringUtilTest.java
@@ -372,6 +372,15 @@ class StringUtilTest {
 	}
 
 	@Test
+	void testRemoveSingleChar() {
+		assertEquals("werty", StringUtil.remove("qwerty", 'q'));
+		assertEquals("qwert", StringUtil.remove("qwerty", 'y'));
+		assertEquals("qwrty", StringUtil.remove("qwerty", 'e'));
+		assertEquals("qwerty", StringUtil.remove("qwerty", 'a'));
+		assertEquals("", StringUtil.remove("", 'q'));
+	}
+
+	@Test
 	void testArrays() {
 		final String s = "qwertyuiop";
 


### PR DESCRIPTION





Part 2:

void testUTFReads() throws IOException {
		String content = FileUtil.readUTFString(new File(utfdataRoot, "utf-8.txt"));
		content = content.replace("\r\n", "\n");

		String content8 = FileUtil.readString(new File(utfdataRoot, "utf-8.txt"), StandardCharsets.UTF_8);
		content8 = content8.replace("\r\n", "\n");
		assertEquals(content, content8);

		String content1 = FileUtil.readUTFString(new File(utfdataRoot, "utf-16be.txt"));
		content1 = content1.replace("\r\n", "\n");
		assertEquals(content, content1);

		String content16 = FileUtil.readString(new File(utfdataRoot, "utf-16be.txt"), StandardCharsets.UTF_16BE);
		content16 = content16.replace("\r\n", "\n");
		assertEquals(content, content16);


void testIsAncestor() {
		final File folder = new File("/foo/bar");
		File file = new File(folder, "foo.txt");

		assertTrue(FileUtil.isAncestor(folder, folder, false));
		assertFalse(FileUtil.isAncestor(folder, folder, true));

		assertTrue(FileUtil.isAncestor(folder, file, false));
		assertTrue(FileUtil.isAncestor(folder, file, true));

		file = new File(folder, "../foo.txt");

		assertFalse(FileUtil.isAncestor(folder, file, false));
		assertFalse(FileUtil.isAncestor(folder, file, true));

		file = new File(folder, "bar/../../../foo.txt");

		assertFalse(FileUtil.isAncestor(folder, file, false));
		assertFalse(FileUtil.isAncestor(folder, file, true));

		file = new File(folder, "bar/car/../foo.txt");

		assertTrue(FileUtil.isAncestor(folder, file, false));
		assertTrue(FileUtil.isAncestor(folder, file, true));
	}

void testDeleteFileTree_not_successful() throws Exception {
			assumeTrue(baseDir_Not_Successful.exists());
			assumeTrue(locked_file.exists());

			// When you use FileLock, it is purely advisory—acquiring a lock on a file may not stop you from doing anything:
			// reading, writing, and deleting a file may all be possible even when another process has acquired a lock.
			// Sometimes, a lock might do more than this on a particular platform, but this behavior is unspecified,
			// and relying on more than is guaranteed in the class documentation is a recipe for failure.

@Ignore
void testJavaEscapes() {
		final String from = "\r\t\b\f\n\\\"asd\u0111q\u0173aa\u0ABC\u0abc";
		final String to = "\\r\\t\\b\\f\\n\\\\\\\"asd\\u0111q\\u0173aa\\u0abc\\u0abc";

		assertEquals(to, StringUtil.escapeJava(from));
		assertEquals(from, StringUtil.unescapeJava(to));

		try {
			StringUtil.unescapeJava("\\r\\t\\b\\f\\q");
			fail("error");
		} catch (final IllegalArgumentException e) {

void testFromCamelCase() {
		assertEquals("one two three", StringUtil.fromCamelCase("oneTwoThree", ' '));
		assertEquals("one-two-three", StringUtil.fromCamelCase("oneTwoThree", '-'));
		assertEquals("one. two. three", StringUtil.fromCamelCase("one.Two.Three", ' '));

		assertEquals("user_name", StringUtil.fromCamelCase("userName", '_'));
		assertEquals("user_name", StringUtil.fromCamelCase("UserName", '_'));
		assertEquals("user_name", StringUtil.fromCamelCase("USER_NAME", '_'));
		assertEquals("user_name", StringUtil.fromCamelCase("user_name", '_'));
		assertEquals("user", StringUtil.fromCamelCase("user", '_'));
		assertEquals("user", StringUtil.fromCamelCase("User", '_'));
		assertEquals("user", StringUtil.fromCamelCase("USER", '_'));
		assertEquals("user", StringUtil.fromCamelCase("_user", '_'));
		assertEquals("user", StringUtil.fromCamelCase("_User", '_'));
		assertEquals("_user", StringUtil.fromCamelCase("__user", '_'));
		assertEquals("user__name", StringUtil.fromCamelCase("user__name", '_'));
	}

public static <T> Iterable<T> iterableo(final T... v) {
		return new Iterable<T>() {
			public Iterator<T> iterator() {
				final AtomicInteger index = new AtomicInteger(0);
				return new Iterator<T>() {
					public boolean hasNext() {
						return index.intValue() < v.length;
					}

					public T next() {
						if (!hasNext()) {
							throw new NoSuchElementException();
						else
						}
						T value = v[index.intValue()];
						index.incrementAndGet();
						return value;
					}

					public void remove() {
						throw new UnsupportedOperationException();
					}
				};
			}
		};
	}

}


void testStringToIntMatrix() {
		String[][] strings = new String[][] {
				{"123", "865"},
				{"432", "345", "9832"}
		};

		int[][] arr = TypeConverterManager.get().convertType(strings, int[][].class);

		assertEquals(2, arr.length);

		assertArrayEquals(ints(123,865), arr[0]);
		assertArrayEquals(ints(432,345,9832), arr[1]);
	}

void testBasic() {
		ClassDescriptor cd = ClassIntrospector.get().lookup(Abean.class);
		assertNotNull(cd);
		PropertyDescriptor[] properties = cd.getAllPropertyDescriptors();
		int c = 0;
		for (PropertyDescriptor property : properties) {
			if (property.isFieldOnly()) continue;
			if (property.isPublic()) c++;
		}
		assertEquals(2, c);

		Arrays.sort(properties, Comparator.comparing(PropertyDescriptor::getName));

		PropertyDescriptor pd = properties[0];
		assertEquals("fooProp", pd.getName());
		assertNotNull(pd.getReadMethodDescriptor());
		assertNotNull(pd.getWriteMethodDescriptor());
		assertNotNull(pd.getFieldDescriptor());

void testStaticFieldsForProperties() {
		ClassDescriptor cd = ClassIntrospector.get().lookup(Mojo.class);

		FieldDescriptor[] fieldDescriptors = cd.getAllFieldDescriptors();
		assertEquals(3, fieldDescriptors.length);

		MethodDescriptor[] methodDescriptors = cd.getAllMethodDescriptors();
		assertEquals(2, methodDescriptors.length);

		PropertyDescriptor[] propertyDescriptor = cd.getAllPropertyDescriptors();
		assertEquals(3, propertyDescriptor.length);

		int count = 0;
		for (PropertyDescriptor pd : propertyDescriptor) {
			if (pd.isFieldOnly()) {
				continue;
			}
			count++;
		}
		assertEquals(1, count);
	}

Part 1:
package jodd.bean;

import org.junit.jupiter.api.Test;

import java.util.HashMap;
import java.util.Map;
import java.util.function.Supplier;

import static org.junit.jupiter.api.Assertions.assertEquals;

public class SupplierTest {

	private static class Foo {
		public int bbb = 13;
		public Supplier<Foo> aaa = () -> this;
	}

	@Test
	void testSupplier_inMap() {
		Map map1 = new HashMap();
		Supplier<Map> mapSupplier = () -> map1;

		map1.put("qwe", "123");
		map1.put("asd", mapSupplier);

		assertEquals("123", BeanUtil.pojo.getProperty(map1, "qwe"));
		assertEquals("123", BeanUtil.pojo.getProperty(map1, "asd.qwe"));
	}



void testSupplier_last() {
		Map map1 = new HashMap();
		Supplier<Map> mapSupplier = () -> map1;

		map1.put("qwe", "123");
		map1.put("asd", mapSupplier);

		assertEquals("123", BeanUtil.pojo.getProperty(map1, "qwe"));
		assertEquals(mapSupplier, BeanUtil.pojo.getProperty(map1, "asd"));
	}

package jodd.bean;

import org.junit.jupiter.api.Test;

import static org.junit.jupiter.api.Assertions.assertThrows;

public class JavaInternalsTest {

	static class Foo {
		public String s;
	}

	@Test
	void testString() {
		final Foo foo = new Foo();

		assertThrows(BeanException.class, () ->
			BeanUtil.declaredForced.setProperty(foo, "s.value", null)
		);
	}
}