### PR TITLE
Update JulianDate calculations

### DIFF
--- a/src/test/java/jodd/time/JulianDateTest.java
+++ b/src/test/java/jodd/time/JulianDateTest.java
@@ -58,7 +58,7 @@ class JulianDateTest {
 		JulianDate jdt2 = new JulianDate(2440600, 0.09999999991);
 		assertTrue(ldt.isEqual(jdt2.toLocalDateTime()));
 
-		JulianDate jdt3 = new JulianDate(2440600, 0.10000001);
+		JulianDate jdt3 = new JulianDate(2440600, 0.100000001);
 		assertTrue(ldt.isEqual(jdt3.toLocalDateTime()));
 	}
 
@@ -84,4 +84,210 @@ class JulianDateTest {
 		assertEquals("2003-02-28T23:59:59.999", jdt.toLocalDateTime().format(ISO_LOCAL_DATE_TIME));
 	}
 
+	@Test
+	void testRoundTripDouble() {
+		double doubleValue = 2457754.4;
+		JulianDate jdt = JulianDate.of(doubleValue);
+		assertEquals(doubleValue, jdt.doubleValue());
+
+		doubleValue = 2457754.5;
+		jdt = JulianDate.of(doubleValue);
+		assertEquals(doubleValue, jdt.doubleValue());
+
+		doubleValue = 2457754.6;
+		jdt = JulianDate.of(doubleValue);
+		assertEquals(doubleValue, jdt.doubleValue());
+
+		doubleValue = 2457754.7;
+		jdt = JulianDate.of(doubleValue);
+		assertEquals(doubleValue, jdt.doubleValue());
+
+		doubleValue = 2457754.8;
+		jdt = JulianDate.of(doubleValue);
+		assertEquals(doubleValue, jdt.doubleValue());
+
+		doubleValue = 2457448.43219907;
+		jdt = JulianDate.of(doubleValue);
+		assertEquals(doubleValue, jdt.doubleValue());
+	}
+
+	@Test
+	void testRoundTripLocalDateTime() {
+		LocalDateTime ldt = LocalDateTime.of(2016, 12, 31, 21, 36, 0, 0);
+		JulianDate jdt = JulianDate.of(ldt);
+		assertEquals(ldt, jdt.toLocalDateTime());
+
+		ldt = LocalDateTime.of(2017, 1, 1, 0, 0, 0, 0);
+		jdt = JulianDate.of(ldt);
+		assertEquals(ldt, jdt.toLocalDateTime());
+
+		ldt = LocalDateTime.of(2017, 1, 1, 2, 24, 0, 0);
+		jdt = JulianDate.of(ldt);
+		assertEquals(ldt, jdt.toLocalDateTime());
+
+		ldt = LocalDateTime.of(2017, 1, 1, 4, 48, 0, 0);
+		jdt = JulianDate.of(ldt);
+		assertEquals(ldt, jdt.toLocalDateTime());
+
+		ldt = LocalDateTime.of(2017, 1, 1, 7, 12, 0, 0);
+		jdt = JulianDate.of(ldt);
+		assertEquals(ldt, jdt.toLocalDateTime());
+
+		ldt = LocalDateTime.of(2016, 2, 29, 22, 22, 22, 0);
+		jdt = JulianDate.of(ldt);
+		assertEquals(ldt, jdt.toLocalDateTime());
+	}
+
+	@Test
+	void testRoundTripMilliseconds() {
+		long milliseconds = 1483220160000L;
+		JulianDate jdt = JulianDate.of(milliseconds);
+		assertEquals(milliseconds, jdt.toMilliseconds());
+
+		milliseconds = 1483228800000L;
+		jdt = JulianDate.of(milliseconds);
+		assertEquals(milliseconds, jdt.toMilliseconds());
+
+		milliseconds = 1483237440000L;
+		jdt = JulianDate.of(milliseconds);
+		assertEquals(milliseconds, jdt.toMilliseconds());
+
+		milliseconds = 1483246080000L;
+		jdt = JulianDate.of(milliseconds);
+		assertEquals(milliseconds, jdt.toMilliseconds());
+
+		milliseconds = 1483254720000L;
+		jdt = JulianDate.of(milliseconds);
+		assertEquals(milliseconds, jdt.toMilliseconds());
+
+		milliseconds = 1456784542000L;
+		jdt = JulianDate.of(milliseconds);
+		assertEquals(milliseconds, jdt.toMilliseconds());
+	}
+
+	@Test
+	void testDoubleToLocalDateTime() {
+		JulianDate jdt = JulianDate.of(2457754.4);
+		assertEquals(LocalDateTime.of(2016, 12, 31, 21, 36, 0, 0), jdt.toLocalDateTime());
+
+		jdt = JulianDate.of(2457754.5);
+		assertEquals(LocalDateTime.of(2017, 1, 1, 0, 0, 0, 0), jdt.toLocalDateTime());
+
+		jdt = JulianDate.of(2457754.6);
+		assertEquals(LocalDateTime.of(2017, 1, 1, 2, 24, 0, 0), jdt.toLocalDateTime());
+
+		jdt = JulianDate.of(2457754.7);
+		assertEquals(LocalDateTime.of(2017, 1, 1, 4, 48, 0, 0), jdt.toLocalDateTime());
+
+		jdt = JulianDate.of(2457754.8);
+		assertEquals(LocalDateTime.of(2017, 1, 1, 7, 12, 0, 0), jdt.toLocalDateTime());
+
+		jdt = JulianDate.of(2457448.43219907);
+		assertEquals(LocalDateTime.of(2016, 2, 29, 22, 22, 22, 0), jdt.toLocalDateTime());
+	}
+
+	@Test
+	void testDoubleToMilliseconds() {
+		JulianDate jdt = JulianDate.of(2457754.4);
+		assertEquals(1483220160000L, jdt.toMilliseconds());
+
+		jdt = JulianDate.of(2457754.5);
+		assertEquals(1483228800000L, jdt.toMilliseconds());
+
+		jdt = JulianDate.of(2457754.6);
+		assertEquals(1483237440000L, jdt.toMilliseconds());
+
+		jdt = JulianDate.of(2457754.7);
+		assertEquals(1483246080000L, jdt.toMilliseconds());
+
+		jdt = JulianDate.of(2457754.8);
+		assertEquals(1483254720000L, jdt.toMilliseconds());
+
+		jdt = JulianDate.of(2457448.43219907);
+		assertEquals(1456784542000L, jdt.toMilliseconds());
+	}
+
+	@Test
+	void testLocalDateTimeToDouble() {
+		JulianDate jdt = JulianDate.of(LocalDateTime.of(2016, 12, 31, 21, 36, 0, 0));
+		assertEquals(2457754.4, jdt.doubleValue());
+
+		jdt = JulianDate.of(LocalDateTime.of(2017, 1, 1, 0, 0, 0, 0));
+		assertEquals(2457754.5, jdt.doubleValue());
+
+		jdt = JulianDate.of(LocalDateTime.of(2017, 1, 1, 2, 24, 0, 0));
+		assertEquals(2457754.6, jdt.doubleValue());
+
+		jdt = JulianDate.of(LocalDateTime.of(2017, 1, 1, 4, 48, 0, 0));
+		assertEquals(2457754.7, jdt.doubleValue());
+
+		jdt = JulianDate.of(LocalDateTime.of(2017, 1, 1, 7, 12, 0, 0));
+		assertEquals(2457754.8, jdt.doubleValue());
+
+		jdt = JulianDate.of(LocalDateTime.of(2016, 2, 29, 22, 22, 22, 0));
+		assertEquals(2457448.4321990740, jdt.doubleValue(), 1.0e-10);
+	}
+
+	@Test
+	void testLocalDateTimeToMilliseconds() {
+		JulianDate jdt = JulianDate.of(LocalDateTime.of(2016, 12, 31, 21, 36, 0, 0));
+		assertEquals(1483220160000L, jdt.toMilliseconds());
+
+		jdt = JulianDate.of(LocalDateTime.of(2017, 1, 1, 0, 0, 0, 0));
+		assertEquals(1483228800000L, jdt.toMilliseconds());
+
+		jdt = JulianDate.of(LocalDateTime.of(2017, 1, 1, 2, 24, 0, 0));
+		assertEquals(1483237440000L, jdt.toMilliseconds());
+
+		jdt = JulianDate.of(LocalDateTime.of(2017, 1, 1, 4, 48, 0, 0));
+		assertEquals(1483246080000L, jdt.toMilliseconds());
+
+		jdt = JulianDate.of(LocalDateTime.of(2017, 1, 1, 7, 12, 0, 0));
+		assertEquals(1483254720000L, jdt.toMilliseconds());
+
+		jdt = JulianDate.of(LocalDateTime.of(2016, 2, 29, 22, 22, 22, 0));
+		assertEquals(1456784542000L, jdt.toMilliseconds());
+	}
+
+	@Test
+	void testMillisecondsToDouble() {
+		JulianDate jdt = JulianDate.of(1483220160000L);
+		assertEquals(2457754.4, jdt.doubleValue());
+
+		jdt = JulianDate.of(1483228800000L);
+		assertEquals(2457754.5, jdt.doubleValue());
+
+		jdt = JulianDate.of(1483237440000L);
+		assertEquals(2457754.6, jdt.doubleValue());
+
+		jdt = JulianDate.of(1483246080000L);
+		assertEquals(2457754.7, jdt.doubleValue());
+
+		jdt = JulianDate.of(1483254720000L);
+		assertEquals(2457754.8, jdt.doubleValue());
+
+		jdt = JulianDate.of(1456784542000L);
+		assertEquals(2457448.432199074, jdt.doubleValue(), 1.0e-10);
+	}
+
+	@Test
+	void testMillisecondsToLocalDateTime() {
+		JulianDate jdt = JulianDate.of(1483220160000L);
+		assertEquals(LocalDateTime.of(2016, 12, 31, 21, 36, 0, 0), jdt.toLocalDateTime());
+
+		jdt = JulianDate.of(1483228800000L);
+		assertEquals(LocalDateTime.of(2017, 1, 1, 0, 0, 0, 0), jdt.toLocalDateTime());
+
+		jdt = JulianDate.of(1483237440000L);
+		assertEquals(LocalDateTime.of(2017, 1, 1, 2, 24, 0, 0), jdt.toLocalDateTime());
+
+		jdt = JulianDate.of(1483246080000L);
+		assertEquals(LocalDateTime.of(2017, 1, 1, 4, 48, 0, 0), jdt.toLocalDateTime());
+
+		jdt = JulianDate.of(1483254720000L);
+		assertEquals(LocalDateTime.of(2017, 1, 1, 7, 12, 0, 0), jdt.toLocalDateTime());
+
+		jdt = JulianDate.of(1456784542000L);
+		assertEquals(LocalDateTime.of(2016, 2, 29, 22, 22, 22, 0), jdt.toLocalDateTime());
+	}
 }


### PR DESCRIPTION
This is meant to address a handful of issues in the `JulianDate` class:

1. Converting certain JD values to a LocalDateTime would throw an exception, e.g.
```
JulianDate.of(2457754.8).toLocalDateTime()
```
```
Invalid value for NanoOfSecond (valid values 0 - 999999999): 1000000000
```

2. The fact that milliseconds are generally truncated rather than rounded leads to some strange conversions results, e.g.
```
JulianDate.of(2457754.4).toMilliseconds()
```
```
1483220159999
```
Notably `toMilliseconds` would sometimes return a different time than `toLocalDateTime`.

3. Converting from MJD/TJD/RJD is more complicated than going the other direction.

4. Adding or subtracting large double values throws an error (not sure if this is intentional for optimization purposes, but if so it was undocumented).

5. No ability to take in/return an `Instant`.

One thing that is hinted at above but not addressed, is the fact that even though one might expect conversion to/from milliseconds and LocalDateTime (and/or Instant) to always result in the same value, the fact different calculations are used in the two code paths makes me suspect there might still be a way to get different results from the two (even though with the rounding changes the cases I tried seem to be fixed). Thus I would also suggest it might be having a single representation used as the base for all such conversions. If such a change is welcome, I can add this as well, but it would be good to know which method is considered more accurate/precise.

If there are any changes needed here, I'm happy to make another pass at this.

Thanks!