### PR TITLE
Make ClassUtil#forceOpen trap all RuntimeException

### DIFF
--- a/src/main/java/jodd/util/ClassUtil.java
+++ b/src/main/java/jodd/util/ClassUtil.java
@@ -510,7 +510,7 @@ public class ClassUtil {
 					return null;
 				});
 			}
-		} catch (final SecurityException sex) {
+		} catch (final RuntimeException ex) {
 			// ignore
 		}
 	}


### PR DESCRIPTION
Motivation:

Starting Java 9, this piece of code can also throw a java.lang.reflect.InaccessibleObjectException.

Modification:

As this Exception appeared in Java 9 and jodd is compatible with Java 8, we have no choice but to trap the parent class which is RuntimeException.

Result:

Jodd reflection doesn't choke on unopened classes.